### PR TITLE
Return `reserved`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -4,6 +4,7 @@ import isIp from "is-ip"
 interface IpApiData {
 	ip: string
 	city: string
+	reserved: boolean 
 	region: string
 	region_code: string
 	country: string
@@ -81,12 +82,13 @@ async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
 		throw new TypeError("A valid ipv4 address must be provided!")
 	}
 
-	const { latitude, longitude, city, region, region_code, country_name, country_code, country_code_iso3, country_capital, country_tld, country_population, country_calling_code, continent_code, in_eu, postal, timezone, utc_offset, currency, currency_name, languages, country_area }: IpApiData = await ky(`https://ipapi.co/${ip}/json/`).json()
+	const { latitude, longitude, city, reserved, region, region_code, country_name, country_code, country_code_iso3, country_capital, country_tld, country_population, country_calling_code, continent_code, in_eu, postal, timezone, utc_offset, currency, currency_name, languages, country_area }: IpApiData = await ky(`https://ipapi.co/${ip}/json/`).json()
 
 	return {
 		latitude,
 		longitude,
 		city,
+		reserved: !!reserved,
 		region: {
 			name: region,
 			code: region_code
@@ -109,7 +111,7 @@ async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
 				name: currency_name,
 				code: currency
 			},
-			languages: languages.split(",")
+			languages: languages ? languages.split(",") : languages
 		},
 		continent: {
 			code: continent_code,

--- a/source/index.ts
+++ b/source/index.ts
@@ -4,7 +4,7 @@ import isIp from "is-ip"
 interface IpApiData {
 	ip: string
 	city: string
-	reserved: boolean 
+	reserved: boolean
 	region: string
 	region_code: string
 	country: string
@@ -30,15 +30,14 @@ interface IpApiData {
 
 declare namespace ipLocation {
 	export interface LocationData {
-		latitude?: number
-		longitude?: number
-		city?: string
-		reserved?: boolean
-		region?: {
+		latitude: number
+		longitude: number
+		city: string
+		region: {
 			name: string
 			code: string
 		}
-		country?: {
+		country: {
 			name: string
 			code: string
 			iso3: string
@@ -58,11 +57,17 @@ declare namespace ipLocation {
 			}
 			languages: string[]
 		}
-		continent?: {
+		continent: {
 			code: string
 			inEu: boolean
 		}
 	}
+
+	export interface ReservedData {
+		reserved: boolean
+	}
+
+	export type ReturnType = (LocationData & ReservedData) | ReservedData
 }
 
 /**
@@ -78,7 +83,7 @@ const ipLocation = require("ip-location");
 })();
 ```
 */
-async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
+async function ipLocation(ip: string): Promise<ipLocation.ReturnType> {
 	if (typeof ip !== "string" || !isIp.v4(ip)) {
 		throw new TypeError("A valid ipv4 address must be provided!")
 	}
@@ -91,7 +96,7 @@ async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
 		latitude,
 		longitude,
 		city,
-		reserved: !!reserved,
+		reserved: Boolean(reserved),
 		region: {
 			name: region,
 			code: region_code
@@ -114,7 +119,7 @@ async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
 				name: currency_name,
 				code: currency
 			},
-			languages: languages ? languages.split(",") : languages
+			languages: languages ? languages.split(",") : []
 		},
 		continent: {
 			code: continent_code,

--- a/source/index.ts
+++ b/source/index.ts
@@ -30,14 +30,15 @@ interface IpApiData {
 
 declare namespace ipLocation {
 	export interface LocationData {
-		latitude: number
-		longitude: number
-		city: string
-		region: {
+		latitude?: number
+		longitude?: number
+		city?: string
+		reserved?: boolean
+		region?: {
 			name: string
 			code: string
 		}
-		country: {
+		country?: {
 			name: string
 			code: string
 			iso3: string
@@ -57,7 +58,7 @@ declare namespace ipLocation {
 			}
 			languages: string[]
 		}
-		continent: {
+		continent?: {
 			code: string
 			inEu: boolean
 		}
@@ -84,7 +85,9 @@ async function ipLocation(ip: string): Promise<ipLocation.LocationData> {
 
 	const { latitude, longitude, city, reserved, region, region_code, country_name, country_code, country_code_iso3, country_capital, country_tld, country_population, country_calling_code, continent_code, in_eu, postal, timezone, utc_offset, currency, currency_name, languages, country_area }: IpApiData = await ky(`https://ipapi.co/${ip}/json/`).json()
 
-	return {
+	return reserved ? {
+		reserved
+	} : {
 		latitude,
 		longitude,
 		city,

--- a/test.ts
+++ b/test.ts
@@ -6,6 +6,7 @@ test("main", async t => {
 		latitude: -33.8591,
 		longitude: 151.2002,
 		city: "Sydney",
+		reserved: false,
 		region: { name: "New South Wales", code: "NSW" },
 		country: {
 			name: "Australia",


### PR DESCRIPTION
In local testing, the IP 127.0.0.1 response does not contain language property, throwing "TypeError: Cannot read property 'split' of undefined"
Added property `reserved` in function return

https://ipapi.co/127.0.0.1/json/
```
{
    "ip": "127.0.0.1",
    "reserved": true
}
```